### PR TITLE
Make SecueOS submodule work

### DIFF
--- a/addon.gradle
+++ b/addon.gradle
@@ -1,0 +1,5 @@
+task updateSecureOS(type: Exec) {
+	commandLine 'git', 'submodule', 'update', '--init'
+}
+
+processResources.dependsOn updateSecureOS


### PR DESCRIPTION
This *should* include the SecureOS submodule in the build.