### PR TITLE
Add Localization

### DIFF
--- a/src/main/resources/assets/opensecurity/lang/en_US.lang
+++ b/src/main/resources/assets/opensecurity/lang/en_US.lang
@@ -18,6 +18,7 @@ item.magCard.name=Magnetic Strip Card
 item.rfidReaderCard.name=RFID Reader Card
 item.secureNetworkCard.name=Secure Network Card
 item.securityDoor.name=Security Door
+tile.securityDoor.name=Security Door
 item.securityDoorPrivate.name=Private Security Door
 item.damageUpgrade.name=Damage Upgrade
 item.movementUpgrade.name=Movement Upgrade


### PR DESCRIPTION
This adds some missing localizations for unlocalized names returned by the ItemStack-insensitive version of `Item.getUnlocalizedName()`.
Relevant for the Item/Block stats introduced in https://github.com/GTNewHorizons/Hodgepodge/pull/398.